### PR TITLE
chore: add type for hashmaps

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export * from './theme.type';
-export * from './statusCode.type';
+export * from "./statusCode.type";
+export * from "./theme.type";
 
-export type TLang = 'pt' | 'es' | 'en'
+export type TLang = "pt" | "es" | "en";

--- a/src/types/statusCode.type.ts
+++ b/src/types/statusCode.type.ts
@@ -38,7 +38,7 @@ export type StatusCodes = SuccessStatusCode &
   ServerErrorStatusCode;
 
 export type StatusTranslations = {
-  [key in TStatusCode]: {
-    [key in TLang]: string;
+  [status in TStatusCode]: {
+    [lang in TLang]: string;
   };
 };

--- a/src/types/statusCode.type.ts
+++ b/src/types/statusCode.type.ts
@@ -1,14 +1,44 @@
+import { TLang } from ".";
+
 export interface IStatusCode {
-  statusCode: string | number
-  name: string
-  description: string
+  statusCode: string | number;
+  name: string;
+  description: string;
 }
 
-export type TStatusCode = 'success' | 'client_error' | 'server_error' | 'unknown'
+export type TStatusCode =
+  | "success"
+  | "client_error"
+  | "server_error"
+  | "unknown";
 
 export enum EStatusTheme {
-  SUCCESS = 'success',
-  CLIENT_ERROR = 'client_error',
-  SERVER_ERROR = 'server_error',
-  UNKNOWN = 'unknown'
+  SUCCESS = "success",
+  CLIENT_ERROR = "client_error",
+  SERVER_ERROR = "server_error",
+  UNKNOWN = "unknown",
 }
+
+export type SuccessStatusCode = 200 | 204;
+
+export type ClientErrorStatusCode =
+  | 400
+  | 401
+  | 403
+  | 404
+  | 409
+  | 422
+  | 429
+  | 499;
+
+export type ServerErrorStatusCode = 500 | 502 | 504;
+
+export type StatusCodes = SuccessStatusCode &
+  ClientErrorStatusCode &
+  ServerErrorStatusCode;
+
+export type StatusTranslations = {
+  [key in TStatusCode]: {
+    [key in TLang]: string;
+  };
+};

--- a/src/types/theme.type.ts
+++ b/src/types/theme.type.ts
@@ -1,5 +1,5 @@
 export interface IThemeProps {
-  theme: { [key: string]: string } | TTheme
+  theme: { [key: string]: string } | TTheme;
 }
 
-export type TTheme = 'success' | 'client_error' | 'server_error';
+export type TTheme = "success" | "client_error" | "server_error";

--- a/src/utils/getMessagesByTheme.util.ts
+++ b/src/utils/getMessagesByTheme.util.ts
@@ -1,34 +1,34 @@
-import { EStatusTheme, TLang } from '../types';
+import { EStatusTheme, StatusTranslations, TLang } from "../types";
 
 const getMessagesByTheme = (theme: EStatusTheme, lang?: TLang) => {
-	const message = {
-		[EStatusTheme.SUCCESS]: {
-			en: 'Your request was submitted successfully!',
-			es: '¡Su solicitud se envió correctamente!',
-			pt: 'Sua solicitação foi enviada com sucesso!'
-		},
-		[EStatusTheme.CLIENT_ERROR]: {
-			en: 'An error occurred with your client!',
-			es: '¡Se produjo un error con su cliente!',
-			pt: 'Ocorreu um erro com o seu cliente!'
-		},
-		[EStatusTheme.SERVER_ERROR]: {
-			en: 'Resource not found, an error occurred with the system server',
-			es: 'Recurso no encontrado, se produjo un error con el servidor del sistema',
-			pt: 'Recurso não encontrado, ocorreu um erro com o servidor do sistema'
-		},
-		[EStatusTheme.UNKNOWN]: {
-			pt: 'Retorno desconhecido para darmos alguma especificação!',
-			es: '¡Respuesta desconocida para especificaciones!',
-			en: 'Unknown response for specifications!'
-		}
-	};
+  const message: StatusTranslations = {
+    [EStatusTheme.SUCCESS]: {
+      en: "Your request was submitted successfully!",
+      es: "¡Su solicitud se envió correctamente!",
+      pt: "Sua solicitação foi enviada com sucesso!",
+    },
+    [EStatusTheme.CLIENT_ERROR]: {
+      en: "An error occurred with your client!",
+      es: "¡Se produjo un error con su cliente!",
+      pt: "Ocorreu um erro com o seu cliente!",
+    },
+    [EStatusTheme.SERVER_ERROR]: {
+      en: "Resource not found, an error occurred with the system server",
+      es: "Recurso no encontrado, se produjo un error con el servidor del sistema",
+      pt: "Recurso não encontrado, ocorreu um erro com o servidor do sistema",
+    },
+    [EStatusTheme.UNKNOWN]: {
+      pt: "Retorno desconhecido para darmos alguma especificação!",
+      es: "¡Respuesta desconocida para especificaciones!",
+      en: "Unknown response for specifications!",
+    },
+  };
 
-	if (lang) {
-		return message[theme][lang];
-	}
+  if (lang) {
+    return message[theme][lang];
+  }
 
-	return message[theme]['en'] || '';
+  return message[theme]["en"] || "";
 };
 
 export default getMessagesByTheme;

--- a/src/utils/getThemIcon.util.tsx
+++ b/src/utils/getThemIcon.util.tsx
@@ -1,26 +1,26 @@
-import React from 'react';
-import { AiFillCheckCircle } from 'react-icons/ai';
-import { BiSolidErrorAlt } from 'react-icons/bi';
-import { LuServerOff } from 'react-icons/lu';
-import { MdSmsFailed } from 'react-icons/md';
-import { EStatusTheme, TLang } from '../types';
-import getToastTitleByTheme from './getToastTitleByTheme.util';
-import "./index.css"
+import React from "react";
+import { AiFillCheckCircle } from "react-icons/ai";
+import { BiSolidErrorAlt } from "react-icons/bi";
+import { LuServerOff } from "react-icons/lu";
+import { MdSmsFailed } from "react-icons/md";
+import { EStatusTheme, TLang } from "../types";
+import getToastTitleByTheme from "./getToastTitleByTheme.util";
+import "./index.css";
 
 const getThemeIcon = (theme: EStatusTheme, lang?: TLang) => {
-	const themeIcons = {
-		success: <AiFillCheckCircle />,
-		client_error: <BiSolidErrorAlt />,
-		server_error: <LuServerOff />,
-		unknown: <MdSmsFailed />
-	};
+  const themeIcons = {
+    success: <AiFillCheckCircle />,
+    client_error: <BiSolidErrorAlt />,
+    server_error: <LuServerOff />,
+    unknown: <MdSmsFailed />,
+  };
 
-	return (
-		<div className='theme_icon'>
-			{themeIcons[theme]}
-			{getToastTitleByTheme(theme, lang)}
-		</div>
-	);
+  return (
+    <div className="theme_icon">
+      {themeIcons[theme]}
+      {getToastTitleByTheme(theme, lang)}
+    </div>
+  );
 };
 
 export default getThemeIcon;

--- a/src/utils/getThemeByStatusCode.util.ts
+++ b/src/utils/getThemeByStatusCode.util.ts
@@ -1,30 +1,31 @@
-import { EStatusTheme } from '../types';
+import { EStatusTheme, StatusCodes } from "../types";
 
 const getThemeByStatusCode = (status: string | number): EStatusTheme => {
-	const statusType = new Map<number, EStatusTheme>([
-		[200, EStatusTheme.SUCCESS],
-		[204, EStatusTheme.SUCCESS],
-		[400, EStatusTheme.CLIENT_ERROR],
-		[401, EStatusTheme.CLIENT_ERROR],
-		[403, EStatusTheme.CLIENT_ERROR],
-		[404, EStatusTheme.CLIENT_ERROR],
-		[409, EStatusTheme.CLIENT_ERROR],
-		[422, EStatusTheme.CLIENT_ERROR],
-		[429, EStatusTheme.CLIENT_ERROR],
-		[499, EStatusTheme.CLIENT_ERROR],
-		[500, EStatusTheme.SERVER_ERROR],
-		[502, EStatusTheme.SERVER_ERROR],
-		[504, EStatusTheme.SERVER_ERROR],
-	]);
+  const statusType = new Map<StatusCodes, EStatusTheme>([
+    [200, EStatusTheme.SUCCESS],
+    [204, EStatusTheme.SUCCESS],
+    [400, EStatusTheme.CLIENT_ERROR],
+    [401, EStatusTheme.CLIENT_ERROR],
+    [403, EStatusTheme.CLIENT_ERROR],
+    [404, EStatusTheme.CLIENT_ERROR],
+    [409, EStatusTheme.CLIENT_ERROR],
+    [422, EStatusTheme.CLIENT_ERROR],
+    [429, EStatusTheme.CLIENT_ERROR],
+    [499, EStatusTheme.CLIENT_ERROR],
+    [500, EStatusTheme.SERVER_ERROR],
+    [502, EStatusTheme.SERVER_ERROR],
+    [504, EStatusTheme.SERVER_ERROR],
+  ]);
 
-	const statusString = String(status);
-	for (const [statusCode, theme] of statusType.entries()) {
-		if (statusString === String(statusCode)) {
-			return theme;
-		}
-	}
+  const statusString = String(status);
 
-	return EStatusTheme.UNKNOWN;
+  for (const [statusCode, theme] of statusType.entries()) {
+    if (statusString === String(statusCode)) {
+      return theme;
+    }
+  }
+
+  return EStatusTheme.UNKNOWN;
 };
 
 export default getThemeByStatusCode;

--- a/src/utils/getToastTitleByTheme.util.ts
+++ b/src/utils/getToastTitleByTheme.util.ts
@@ -1,34 +1,34 @@
-import { EStatusTheme, TLang } from '../types';
+import { EStatusTheme, StatusTranslations, TLang } from "../types";
 
 const getToastTitleByTheme = (theme: EStatusTheme, lang?: TLang) => {
-	const title = {
-		[EStatusTheme.SUCCESS]: {
-			en: 'Success',
-			es: 'Éxito',
-			pt: 'Sucesso'
-		},
-		[EStatusTheme.CLIENT_ERROR]: {
-			en: 'Client error',
-			es: 'Error de cliente',
-			pt: 'Erro de cliente'
-		},
-		[EStatusTheme.SERVER_ERROR]: {
-			en: 'Server error',
-			es: 'Error con el servidor',
-			pt: 'Erro de servidor'
-		},
-		[EStatusTheme.UNKNOWN]: {
-			pt: 'Status desconhecido',
-			es: 'Status desconocido',
-			en: 'Unknown status'
-		}
-	};
+  const title: StatusTranslations = {
+    [EStatusTheme.SUCCESS]: {
+      en: "Success",
+      es: "Éxito",
+      pt: "Sucesso",
+    },
+    [EStatusTheme.CLIENT_ERROR]: {
+      en: "Client error",
+      es: "Error de cliente",
+      pt: "Erro de cliente",
+    },
+    [EStatusTheme.SERVER_ERROR]: {
+      en: "Server error",
+      es: "Error con el servidor",
+      pt: "Erro de servidor",
+    },
+    [EStatusTheme.UNKNOWN]: {
+      pt: "Status desconhecido",
+      es: "Status desconocido",
+      en: "Unknown status",
+    },
+  };
 
-	if (lang) {
-		return title[theme][lang];
-	}
+  if (lang) {
+    return title[theme][lang];
+  }
 
-	return title[theme]['en'] || '';
+  return title[theme]["en"] || "";
 };
 
 export default getToastTitleByTheme;


### PR DESCRIPTION
Just created interfaces/types for hashmaps. 

It would be interesting if we have an `.editorconfig` file. Also user probably would like to customize messages for each toast. Any plans for that? Please, lmk!